### PR TITLE
Use myadd.ir for get IP address

### DIFF
--- a/reality-ezpz.sh
+++ b/reality-ezpz.sh
@@ -19,7 +19,7 @@ if [[ ! -e "${path}/config" ]]; then
 key_pair=$(sudo docker run -q --rm teddysun/xray:1.8.0 xray x25519)
 cat >"${path}/config" <<EOF
 domain=${domain}
-server=$(curl -s ifconfig.me)
+server=$(curl -s myadd.ir/ip)
 uuid=$(cat /proc/sys/kernel/random/uuid)
 public_key=$(echo "${key_pair}"|grep -oP '(?<=Public key: ).*')
 private_key=$(echo "${key_pair}"|grep -oP '(?<=Private key: ).*')


### PR DESCRIPTION
The `ifconfig.co` is behind Cloudflare's CDN and blocks some IPs to access it and give a 403 HTTP error. I propose `myadd.ir` to fetch the IP address.