### PR TITLE
fix error docker-compose ls "command not found" coused by old version…

### DIFF
--- a/reality-ezpz.sh
+++ b/reality-ezpz.sh
@@ -720,8 +720,16 @@ function install_docker {
     return 0
   fi
   if which docker-compose >/dev/null 2>&1; then
-    docker_cmd="docker-compose"
-    return 0
+    if ! docker-compose ls >/dev/null 2>&1; then
+      curl -fsSL -m 30 https://github.com/docker/compose/releases/download/v2.28.0/docker-compose-linux-$(uname -m) -o /usr/local/bin/docker-compose
+      chmod +x /usr/local/bin/docker-compose
+      docker_cmd="/usr/local/bin/docker-compose"
+      return 0
+    else
+      docker_cmd="docker-compose"
+      return 0
+    fi
+
   fi
   curl -fsSL -m 30 https://github.com/docker/compose/releases/download/v2.28.0/docker-compose-linux-$(uname -m) -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
Hi , 
in the function "install_docker" there is a small bug. 
if the command docker-compose existed, it uses it in the script but first it should be checked for "docker-compose ls" command existence . because in case docker-compose has already been installed but in older version , it does not have "docker-compose ls" command and script fails to run properly. 
So I add another state to check for "docker-compose ls " existence and if it was not found, download the newer version and use absolute path of newer version not to change the default docker-compose and old installations.